### PR TITLE
[Review] Adding boolean type to recognize in dtypes

### DIFF
--- a/pyblazing/api.py
+++ b/pyblazing/api.py
@@ -748,6 +748,7 @@ def get_dtype_values(dtypes):
             'int': gdf_dtype.GDF_INT32,
             'int32': gdf_dtype.GDF_INT32,
             'int64': gdf_dtype.GDF_INT64,
+            'boolean':gdf_dtype.GDF_BOOL8
         }
         if dicc.get(type_name):
             return dicc[type_name]


### PR DESCRIPTION
When you set the dtype as boolean.
dtypes=['str', 'int32', 'boolean]
bc.create_table('table_name', 'path/file.csv', dtype=dtypes)

Now when a dtype is boolean then it's recognized.