### PR TITLE
[REVIEW] When all rals return empty results we still want to concat

### DIFF
--- a/pyblazing/api.py
+++ b/pyblazing/api.py
@@ -1245,7 +1245,7 @@ def _run_query_get_concat_results(distMetaToken, startTime):
 
     gdf =  None
 
-    if (need_to_concat):
+    if need_to_concat or total_nodes > 1:
         all_gdfs = [result.columns for result in result_list]
         gdf =  concat(all_gdfs, ignore_index=True)
     else:


### PR DESCRIPTION
Example:
ral1 returns empty result
ral2 returns empty result
This fix will concat both empty results and thus generate correctly the final gdf (with correct metadata such as columns names and so on)

Before this fix the final gdf is None and produce invalid result in the case mentioned above 