### PR TITLE
[REVIEW] set default channel blazingsql/label/main

### DIFF
--- a/ci/cpu/build-dev.sh
+++ b/ci/cpu/build-dev.sh
@@ -25,7 +25,11 @@ if [ ! -z "$CONDA_BUILD" ]; then
     IFS=', ' read -r -a array <<< "$CONDA_BUILD"
     for item in "${array[@]}"
     do
-        CONDA_CH=$CONDA_CH" -c "$item
+        if [ $item == "blazingsql" ]; then
+            CONDA_CH=$CONDA_CH" -c blazingsql/label/main"
+        else
+            CONDA_CH=$CONDA_CH" -c "$item
+        fi
     done
 fi
 export CONDA_CH

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -45,7 +45,11 @@ if [ ! -z "$CONDA_BUILD" ]; then
     IFS=', ' read -r -a array <<< "$CONDA_BUILD"
     for item in "${array[@]}"
     do
-        CONDA_CH=$CONDA_CH" -c "$item
+        if [ $item == "blazingsql" ]; then
+            CONDA_CH=$CONDA_CH" -c blazingsql/label/main"
+        else
+            CONDA_CH=$CONDA_CH" -c "$item
+        fi
     done
 fi
 export CONDA_CH


### PR DESCRIPTION
This fix is to avoid the python package blazingsql as a conda channel